### PR TITLE
fix: use window.TextDecoder in browser env

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,6 @@
 module.exports = {
-  roots: [
-    "<rootDir>"
-  ],
+  roots: ["<rootDir>"],
   testEnvironment: "jsdom",
-  testMatch: [
-    "<rootDir>test/?(*.)+(spec|test).[tj]s?(x)"
-  ],
+  testMatch: ["<rootDir>test/?(*.)+(spec|test).[tj]s?(x)"],
+  setupFilesAfterEnv: ["<rootDir>/jestSetup.js"],
 };

--- a/jestSetup.js
+++ b/jestSetup.js
@@ -1,0 +1,4 @@
+import { TextDecoder, TextEncoder } from "util";
+
+window.TextDecoder = TextDecoder;
+window.TextEncoder = TextEncoder;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/macaroon-bakery",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Perform macaroon aware network requests",
   "files": [
     "dist"

--- a/src/bakery.js
+++ b/src/bakery.js
@@ -28,7 +28,10 @@ const ERR_DISCHARGE_REQUIRED = "macaroon discharge required";
 const ERR_INTERACTION_REQUIRED = "interaction required";
 
 let TextDecoder;
-if (!TextDecoder) {
+if (typeof window !== "undefined" && window && window.TextDecoder) {
+  TextDecoder = window.TextDecoder;
+} else {
+  // No window.TextDecoder if it's node.js.
   TextDecoder = util.TextDecoder;
 }
 


### PR DESCRIPTION
## Done

- use `window.TextDecoder` in browser env (TextDecoder was always undefined and util.TextDecoder was used instead of the browser implementation)
- add jest `setupFilesAfterEnv` to add `TextDecoder`/`TextEncoder` to the window before running tests
- bump version to `1.2.1`