### PR TITLE
add back extra dependencies (including crypto-browserify)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2022-07-20
+### Updated
+- Add back extra dependencies to the bundle (e.g. crypto-browserify)
+
+## [1.2.1] - 2022-07-19
+### Updated
+- Added sjcl.js to noParse to remove extra dependencies (e.g. crypto-browserify)
+- Fixed an issue where node util was used instead of window.TextDecoder in browser env
+
 ## [1.2.0] - 2022-06-16
 ### Updated
 - Added Webpack and Babel to build the package.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,6 @@ module.exports = {
     },
   },
   module: {
-    noParse: [/sjcl\.js$/],
     rules: [
       {
         test: /\.m?js$/,


### PR DESCRIPTION
## Done
Add back extra dependencies to the bundle (e.g. crypto-browserify).

## QA steps
1. check out this repository locally
2. `run yarn && yarn build`
3. run `yalc publish` (yalc)[https://github.com/wclr/yalc#installation]
4. run `yalc add @canonical/macaroon-bakery@1.2.2` and `yarn install` in `maas-ui` repository 
5. setup external authentication with RBAC https://webteam.canonical.com/guides/maas-external-authentication-with-rbac
6. Ensure you can login

## Why is this needed
This will fix a webpack error below by adding the crypto-browserify as part of the `bakryjs` package itself.
```
 [1] Module not found: Error: Can't resolve 'crypto' in '/home/ubuntu/code/maas-ui/node_modules/@canonical/macaroon-bakery/dist'
 [1]
 [1] BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
 [1] This is no longer the case. Verify if you need this module and configure a polyfill for it.
 [1]
 [1] If you want to include a polyfill, you need to:
 [1] 	- add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
 [1] 	- install 'crypto-browserify'
 [1] If you don't want to include a polyfill, you can use an empty module like this:
 [1] 	resolve.fallback: { "crypto": false }
```

More on the background for this https://github.com/canonical/web-design-meetings/issues/57#issuecomment-1189745564

---
Alternatively, we can decide to explicitly disable crypto-browserify and suppress webpack warnings (modern browsers support Web Cryptography natively): https://github.com/juju/bakeryjs/pull/43