### PR TITLE
bump version to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/macaroon-bakery",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Perform macaroon aware network requests",
   "files": [
     "dist"


### PR DESCRIPTION
bump version to 1.2.2 in order to release https://github.com/juju/bakeryjs/pull/44